### PR TITLE
add: Add plugin 'timezone' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ export default {
     defaultLocale: 'en',
     defaultTimeZone: 'Asia/Tokyo',
     plugins: [
-      'utc' // import 'dayjs/plugin/utc'
+      'utc', // import 'dayjs/plugin/utc'
+      'timezone' // import 'dayjs/plugin/timezone'
     ] // Your Day.js plugin
   }
   // ...


### PR DESCRIPTION
( メインコントリビューターの方は日本の方ですが一応英語で送ります )

## Resolved Issues
- close #270

## Details of Changes
- Add plugin 'timezone' in README.md
```
dayjs: {
    locales: ['en', 'ja'],
    defaultLocale: 'en',
    defaultTimeZone: 'Asia/Tokyo',
    plugins: ['utc', 'timezone'],
},
```
